### PR TITLE
fix/empty-name-folder: removes all occurrences of // from upload path

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"regexp"
 	"strconv"
 )
 
@@ -24,7 +25,7 @@ func (c *Client) UploadOrUpdateFile(bucketId string, relativePath string, data [
 	c.clientTransport.header.Set("x-upsert", strconv.FormatBool(defaultFileUpsert))
 
 	body := bytes.NewBuffer(data)
-	_path := bucketId + "/" + relativePath
+	_path := removeEmptyFolderName(bucketId + "/" + relativePath)
 
 	var (
 		res *http.Response
@@ -182,6 +183,12 @@ func (c *Client) ListFiles(bucketId string, queryPath string, options FileSearch
 	err = json.Unmarshal(body, &response)
 
 	return response
+}
+
+// removeEmptyFolderName replaces occurances of double slashes (//)  with a single slash /
+// returns a path string with all double slashes replaced with single slash /
+func removeEmptyFolderName(filePath string) string {
+	return regexp.MustCompile(`\/\/`).ReplaceAllString(filePath, "/")
 }
 
 type SortBy struct {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix - addresses [#4633](https://github.com/supabase/supabase/issues/4633)

## What is the current behavior?

Calling 
```Go 
c := storage_go.NewClient(rawUrl, "", map[string]string{})
resp := c.UploadFile("bucket","/folder/file.txt",[]byte("file-contents"))
``` 
or 

```Go
c := storage_go.NewClient(rawUrl, "", map[string]string{})
resp := c.UploadFile("bucket","folder//file.txt",[]byte("file-contents"))
```

creates a folder with no name. This new nameless folder cannot be deleted. 

## What is the new behavior?

Cleans up upload path by replacing any double slashes `//` in the path

## Additional context

Alternatively, this could be a regex test that throws an error when `//` or leading `/` is detected
