### PR TITLE
Feat: Custom file size limit and mime types at bucket level

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -51,11 +51,20 @@ func (c *Client) GetBucket(id string) (Bucket, BucketResponseError) {
 }
 
 func (c *Client) CreateBucket(id string, options BucketOptions) (Bucket, BucketResponseError) {
-	jsonBody, _ := json.Marshal(map[string]interface{}{
+	bodyData := map[string]interface{}{
 		"id":     id,
 		"name":   id,
 		"public": options.Public,
-	})
+	}
+	// We only set the file size limit if it's not empty
+	if len(options.FileSizeLimit) > 0 {
+		bodyData["file_size_limit"] = options.FileSizeLimit
+	}
+	// We only set the allowed mime types if it's not empty
+	if len(options.AllowedMimeTypes) > 0 {
+		bodyData["allowed_mime_types"] = options.AllowedMimeTypes
+	}
+	jsonBody, _ := json.Marshal(bodyData)
 	res, err := c.session.Post(c.clientTransport.baseUrl.String()+"/bucket",
 		"application/json",
 		bytes.NewBuffer(jsonBody))
@@ -74,11 +83,20 @@ func (c *Client) CreateBucket(id string, options BucketOptions) (Bucket, BucketR
 }
 
 func (c *Client) UpdateBucket(id string, options BucketOptions) (MessageResponse, BucketResponseError) {
-	jsonBody, _ := json.Marshal(map[string]interface{}{
+	bodyData := map[string]interface{}{
 		"id":     id,
 		"name":   id,
 		"public": options.Public,
-	})
+	}
+	// We only set the file size limit if it's not empty
+	if len(options.FileSizeLimit) > 0 {
+		bodyData["file_size_limit"] = options.FileSizeLimit
+	}
+	// We only set the allowed mime types if it's not empty
+	if len(options.AllowedMimeTypes) > 0 {
+		bodyData["allowed_mime_types"] = options.AllowedMimeTypes
+	}
+	jsonBody, _ := json.Marshal(bodyData)
 	request, err := http.NewRequest(http.MethodPut, c.clientTransport.baseUrl.String()+"/bucket/"+id, bytes.NewBuffer(jsonBody))
 	res, err := c.session.Do(request)
 	if err != nil {
@@ -138,14 +156,18 @@ type BucketResponseError struct {
 }
 
 type Bucket struct {
-	Id        string `json:"id"`
-	Name      string `json:"name"`
-	Owner     string `json:"owner"`
-	Public    bool   `json:"public"`
-	CreatedAt string `json:"created_at"`
-	UpdatedAt string `json:"updated_at"`
+	Id               string   `json:"id"`
+	Name             string   `json:"name"`
+	Owner            string   `json:"owner"`
+	Public           bool     `json:"public"`
+	FileSizeLimit    string   `json:"file_size_limit"`
+	AllowedMimeTypes []string `json:"allowed_mine_types"`
+	CreatedAt        string   `json:"created_at"`
+	UpdatedAt        string   `json:"updated_at"`
 }
 
 type BucketOptions struct {
-	Public bool
+	Public           bool
+	FileSizeLimit    string
+	AllowedMimeTypes []string
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add a feature to set the bucket size limit and mime types when creating or updating a bucket.

## What is the current behavior?

Refer to JS lib: https://github.com/supabase/storage-js/pull/151

The current way to create a new bucket:
```
client.CreateBucket("test1", storage_go.BucketOptions{
        Public: true,
}))
```

## What is the new behavior?
We add two more fields `FileSizeLimit` and `AllowedMimeTypes` to support it:
```
client.CreateBucket("test1", storage_go.BucketOptions{
	Public: true,
        FileSizeLimit: "10mb",
        AllowedMimeTypes: []string{"image/png", "image/jpeg"},
}))
```
We can leave it empty if we don't want to set it like this
```
client.CreateBucket("test1", storage_go.BucketOptions{
	Public: true,
        FileSizeLimit: "10mb",
}))
```

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
