### PR TITLE
feat: Add create and upload a signed url

### DIFF
--- a/client.go
+++ b/client.go
@@ -5,9 +5,7 @@ import (
 	"net/url"
 )
 
-var (
-	version = "v0.5.6"
-)
+var version = "v0.5.6"
 
 type Client struct {
 	clientError     error

--- a/test/fileupload_test.go
+++ b/test/fileupload_test.go
@@ -2,13 +2,16 @@ package test
 
 import (
 	"fmt"
-	"github.com/supabase-community/storage-go"
 	"os"
 	"testing"
+
+	storage_go "github.com/supabase-community/storage-go"
 )
 
-var rawUrl = "https://abc.supabase.co/storage/v1"
-var token = ""
+var (
+	rawUrl = "https://abc.supabase.co/storage/v1"
+	token  = ""
+)
 
 func TestUpload(t *testing.T) {
 	file, err := os.Open("dummy.txt")
@@ -19,8 +22,8 @@ func TestUpload(t *testing.T) {
 	resp := c.UploadFile("test1", "test.txt", file)
 	fmt.Println(resp)
 
-	//resp = c.UploadFile("test1", "hola.txt", []byte("hello world"))
-	//fmt.Println(resp)
+	// resp = c.UploadFile("test1", "hola.txt", []byte("hello world"))
+	// fmt.Println(resp)
 }
 
 func TestUpdate(t *testing.T) {
@@ -74,4 +77,22 @@ func TestListFile(t *testing.T) {
 	})
 
 	fmt.Println(resp)
+}
+
+func TestCreateUploadSignedUrl(t *testing.T) {
+	c := storage_go.NewClient(rawUrl, token, map[string]string{"apiKey": token})
+	resp, err := c.CreateSignedUploadUrl("your-bucket-id", "book.pdf")
+
+	fmt.Println(resp, err)
+}
+
+func TestUploadToSignedUrl(t *testing.T) {
+	c := storage_go.NewClient(rawUrl, token, map[string]string{"apiKey": token})
+	file, err := os.Open("dummy.txt")
+	if err != nil {
+		panic(err)
+	}
+	resp, err := c.UploadToSignedUrl("signed-url-response", file)
+
+	fmt.Println(resp, err)
 }

--- a/test/storage_test.go
+++ b/test/storage_test.go
@@ -2,8 +2,9 @@ package test
 
 import (
 	"fmt"
-	"github.com/supabase-community/storage-go"
 	"testing"
+
+	"github.com/supabase-community/storage-go"
 )
 
 func TestBucketListAll(t *testing.T) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

We added two new functions for creating a signed upload URL and uploading to a signed URL.

## What is the current behavior?

Refer to JS lib: https://github.com/supabase/storage-js/pull/152

## What is the new behavior?

Example: 
```
resp, err := storage_go.CreateSignedUploadUrl("your-bucket-id", "book.pdf")
```
Response:
```
{ Url: "/object/upload/sign/First Bucket/book.pdf?token=token-from-supabase" }
```

## Additional context

Add any other context or screenshots.
