### PR TITLE
Fix: optional header content-type overridden by default text/plain

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -23,7 +23,7 @@ const (
 
 func (c *Client) UploadOrUpdateFile(bucketId string, relativePath string, data io.Reader, update bool) FileUploadResponse {
 	c.clientTransport.header.Set("cache-control", defaultFileCacheControl)
-	if c.clientTransport.header == nil {
+	if c.clientTransport.header.Get("content-type") == "" {
 		c.clientTransport.header.Set("content-type", defaultFileContentType)
 	}
 	c.clientTransport.header.Set("x-upsert", strconv.FormatBool(defaultFileUpsert))
@@ -33,17 +33,16 @@ func (c *Client) UploadOrUpdateFile(bucketId string, relativePath string, data i
 	var (
 		res *http.Response
 		err error
+		request *http.Request
+		method = http.MethodPost
 	)
 
 	if update {
-		var request *http.Request
-		request, err = http.NewRequest(http.MethodPut, c.clientTransport.baseUrl.String()+"/object/"+_path, body)
-		res, err = c.session.Do(request)
-	} else {
-		var request *http.Request
-		request, err = http.NewRequest(http.MethodPost, c.clientTransport.baseUrl.String()+"/object/"+_path, body)
-		res, err = c.session.Do(request)
+		method = http.MethodPut
 	}
+
+	request, err = http.NewRequest(method, c.clientTransport.baseUrl.String()+"/object/"+_path, body)
+	res, err = c.session.Do(request)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?
- Fix http client overriding the content-type
- Refactor UploadOrUpdateFile request
- Add content-type nil check before assigning the default value

## What is the current behavior?
When you pass the optional headers using `NewClient`, the content-type will get overridden by this:
```go
const defaultFileContentType  = "text/plain;charset=UTF-8"

c.clientTransport.header.Set("content-type", defaultFileContentType)
```
`http.Client` does not override the content-type header that was initially passed via `NewClient`. This means it can't send any file type other than `text/plain`.

## What is the new behavior?
```go
if c.clientTransport.header.Get("content-type") == "" {
          c.clientTransport.header.Set("content-type", defaultFileContentType)
}
...
...
var (
    res *http.Response
    err error
    request *http.Request
    method = http.MethodPost
)

  if update {
	method = http.MethodPut
   }

    request, err = http.NewRequest(method, c.clientTransport.baseUrl.String()+"/object/"+_path, body)
    res, err = c.session.Do(request)
    if err != nil {
	panic(err)
    }
```
With the new change, I add nil checking before assigning default content-type, also refactor request using only one `http.NewRequest` instead of `http.Client`.

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
