### PR TITLE
feat: Add download file function

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -279,6 +279,22 @@ func (c *Client) ListFiles(bucketId string, queryPath string, options FileSearch
 	return response
 }
 
+func (c *Client) DownloadFile(bucketId string, filePath string) ([]byte, error) {
+	request, err := http.NewRequest(
+		http.MethodGet,
+		c.clientTransport.baseUrl.String()+"/object/"+bucketId+"/"+filePath,
+		nil)
+	if err != nil {
+		return nil, err
+	}
+	res, err := c.session.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	body, err := ioutil.ReadAll(res.Body)
+	return body, err
+}
+
 // removeEmptyFolderName replaces occurances of double slashes (//)  with a single slash /
 // returns a path string with all double slashes replaced with single slash /
 func removeEmptyFolderName(filePath string) string {

--- a/test/fileupload_test.go
+++ b/test/fileupload_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"testing"
 
@@ -95,4 +96,20 @@ func TestUploadToSignedUrl(t *testing.T) {
 	resp, err := c.UploadToSignedUrl("signed-url-response", file)
 
 	fmt.Println(resp, err)
+}
+
+func TestDownloadFile(t *testing.T) {
+	c := storage_go.NewClient(rawUrl, token, map[string]string{})
+	resp, err := c.DownloadFile("test1", "book.pdf")
+	if err != nil {
+		fmt.Println(err)
+	}
+
+	file, err := os.Create("book.pdf")
+	if err != nil {
+		fmt.Println(err)
+	}
+	defer file.Close()
+
+	ioutil.WriteFile("book.pdf", resp, 0644)
 }

--- a/test/fileupload_test.go
+++ b/test/fileupload_test.go
@@ -100,16 +100,13 @@ func TestUploadToSignedUrl(t *testing.T) {
 
 func TestDownloadFile(t *testing.T) {
 	c := storage_go.NewClient(rawUrl, token, map[string]string{})
-	resp, err := c.DownloadFile("test1", "book.pdf")
+	resp, err := c.DownloadFile("your-bucket-id", "book.pdf")
 	if err != nil {
-		fmt.Println(err)
+		t.Fatalf("DownloadFile failed: %v", err)
 	}
 
-	file, err := os.Create("book.pdf")
+	err = ioutil.WriteFile("book.pdf", resp, 0644)
 	if err != nil {
-		fmt.Println(err)
+		t.Fatalf("WriteFile failed: %v", err)
 	}
-	defer file.Close()
-
-	ioutil.WriteFile("book.pdf", resp, 0644)
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

We added a new download function which allow user can download file in go code.

## What is the current behavior?

Refer to JS lib: https://github.com/supabase/storage-js/pull/142

## What is the new behavior?

Example:
```
        c := storage_go.NewClient(rawUrl, token, map[string]string{})
	resp, err := c.DownloadFile("test1", "book.pdf")
	if err != nil {
		fmt.Println(err)
	}

	file, err := os.Create("book.pdf")
	if err != nil {
		fmt.Println(err)
	}
	defer file.Close()

	ioutil.WriteFile("book.pdf", resp, 0644)
```

## Additional context

Add any other context or screenshots.
