### PR TITLE
feat: add response code and error message

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -325,6 +325,8 @@ type FileUploadResponse struct {
 	Key     string `json:"Key"`
 	Message string `json:"message"`
 	Data    []byte
+	Code    string    `json:"statusCode"`
+	Error   string    `json:"error"`
 }
 
 type SignedUrlResponse struct {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add new field response code and error message in struct

## What is the current behavior?

Current response doesn't have `status code` and `error message` so when user upload a duplicated file then it doesn't show any warning or error.

## What is the new behavior?

I added `code` and `error` so user will know if the uploaded file is duplicated.

![image](https://github.com/supabase-community/storage-go/assets/47173293/a68649a6-631b-41b1-8171-bb48b2255b61)


## Additional context

Add any other context or screenshots.
