### PR TITLE
chore: update deprecated ioutil functions

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 )
 
@@ -21,7 +20,7 @@ func (c *Client) ListBuckets() ([]Bucket, BucketResponseError) {
 		}
 	}(res.Body)
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		panic(err)
 	}
@@ -41,7 +40,7 @@ func (c *Client) GetBucket(id string) (Bucket, BucketResponseError) {
 		panic(err)
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	var data Bucket
 	var error_ BucketResponseError
 	err = json.Unmarshal(body, &data)
@@ -72,7 +71,7 @@ func (c *Client) CreateBucket(id string, options BucketOptions) (Bucket, BucketR
 		panic(err)
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	var data Bucket
 	var error_ BucketResponseError
 	err = json.Unmarshal(body, &data)
@@ -103,7 +102,7 @@ func (c *Client) UpdateBucket(id string, options BucketOptions) (MessageResponse
 		panic(err)
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	var data MessageResponse
 	var error_ BucketResponseError
 	err = json.Unmarshal(body, &data)
@@ -119,7 +118,7 @@ func (c *Client) EmptyBucket(id string) (MessageResponse, BucketResponseError) {
 		panic(err)
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	var data MessageResponse
 	var error_ BucketResponseError
 	err = json.Unmarshal(body, &data)
@@ -136,7 +135,7 @@ func (c *Client) DeleteBucket(id string) (MessageResponse, BucketResponseError) 
 		panic(err)
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	var data MessageResponse
 	var error_ BucketResponseError
 	err = json.Unmarshal(body, &data)

--- a/client.go
+++ b/client.go
@@ -5,7 +5,7 @@ import (
 	"net/url"
 )
 
-var version = "v0.5.6"
+var version = "v0.6.9"
 
 type Client struct {
 	clientError     error

--- a/storage.go
+++ b/storage.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -48,7 +47,7 @@ func (c *Client) UploadOrUpdateFile(bucketId string, relativePath string, data i
 		panic(err)
 	}
 
-	body_, err := ioutil.ReadAll(res.Body)
+	body_, err := io.ReadAll(res.Body)
 	var response FileUploadResponse
 	err = json.Unmarshal(body_, &response)
 
@@ -80,7 +79,7 @@ func (c *Client) MoveFile(bucketId string, sourceKey string, destinationKey stri
 		panic(err)
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	var response FileUploadResponse
 	err = json.Unmarshal(body, &response)
 
@@ -102,7 +101,7 @@ func (c *Client) CreateSignedUrl(bucketId string, filePath string, expiresIn int
 		panic(err)
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	var response SignedUrlResponse
 	err = json.Unmarshal(body, &response)
 	response.SignedURL = c.clientTransport.baseUrl.String() + response.SignedURL
@@ -123,7 +122,7 @@ func (c *Client) CreateSignedUploadUrl(bucketId string, filePath string) (Signed
 		return SignedUploadUrlResponse{}, err
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return SignedUploadUrlResponse{}, err
 	}
@@ -150,7 +149,7 @@ func (c *Client) UploadToSignedUrl(filePath string, fileBody io.Reader) (*Upload
 		return nil, err
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -194,7 +193,7 @@ func (c *Client) RemoveFile(bucketId string, paths []string) FileUploadResponse 
 		panic(err)
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	var response FileUploadResponse
 	err = json.Unmarshal(body, &response)
 	response.Data = body
@@ -240,7 +239,7 @@ func (c *Client) ListFiles(bucketId string, queryPath string, options FileSearch
 		panic(err)
 	}
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	var response []FileObject
 
 	err = json.Unmarshal(body, &response)
@@ -270,7 +269,7 @@ func (c *Client) DownloadFile(bucketId string, filePath string, urlOptions ...Ur
 		return nil, err
 	}
 	defer res.Body.Close()
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	return body, err
 }
 
@@ -325,8 +324,8 @@ type FileUploadResponse struct {
 	Key     string `json:"Key"`
 	Message string `json:"message"`
 	Data    []byte
-	Code    string    `json:"statusCode"`
-	Error   string    `json:"error"`
+	Code    string `json:"statusCode"`
+	Error   string `json:"error"`
 }
 
 type SignedUrlResponse struct {

--- a/test/fileupload_test.go
+++ b/test/fileupload_test.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -105,7 +104,7 @@ func TestDownloadFile(t *testing.T) {
 		t.Fatalf("DownloadFile failed: %v", err)
 	}
 
-	err = ioutil.WriteFile("book.pdf", resp, 0644)
+	err = os.WriteFile("book.pdf", resp, 0644)
 	if err != nil {
 		t.Fatalf("WriteFile failed: %v", err)
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Issue: https://github.com/supabase-community/storage-go/issues/13

## What is the current behavior?

Update deprecated ioutil function. 
Reference: https://pkg.go.dev/io/ioutil#ReadAll

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
