### PR TITLE
feat(break): introduce an error in the function's response

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,6 +1,9 @@
 package storage_go
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/url"
 )
@@ -58,4 +61,68 @@ func NewClient(rawUrl string, token string, headers map[string]string) *Client {
 	}
 
 	return &c
+}
+
+// NewRequest will create new request with method, url and body
+// If body is not nil, it will be marshalled into json
+func (c *Client) NewRequest(method, url string, body ...interface{}) (*http.Request, error) {
+	var buf io.ReadWriter
+	if len(body) > 0 && body[0] != nil {
+		buf = &bytes.Buffer{}
+		enc := json.NewEncoder(buf)
+		enc.SetEscapeHTML(false)
+		err := enc.Encode(body[0])
+		if err != nil {
+			return nil, err
+		}
+	}
+	req, err := http.NewRequest(method, url, buf)
+	if err != nil {
+		return nil, err
+	}
+	return req, nil
+}
+
+// Do will send request using the c.sessionon which it is called
+// If response contains body, it will be unmarshalled into v
+// If response has err, it will be returned
+func (c *Client) Do(req *http.Request, v interface{}) (*http.Response, error) {
+	resp, err := c.session.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	err = checkForError(resp)
+	if err != nil {
+		return resp, err
+	}
+
+	if resp.Body != nil && v != nil {
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return resp, err
+		}
+		err = json.Unmarshal(body, &v)
+		if err != nil {
+			return resp, err
+		}
+	}
+
+	return resp, nil
+}
+
+func checkForError(resp *http.Response) error {
+	if c := resp.StatusCode; 200 <= c && c < 400 {
+		return nil
+	}
+
+	errorResponse := &StorageError{}
+
+	data, err := io.ReadAll(resp.Body)
+	if err == nil && data != nil {
+		_ = json.Unmarshal(data, errorResponse)
+	}
+
+	return errorResponse
 }

--- a/error.go
+++ b/error.go
@@ -1,0 +1,17 @@
+package storage_go
+
+type StorageError struct {
+	Status  int    `json:"status"`
+	Message string `json:"message"`
+}
+
+func (e *StorageError) Error() string {
+	return e.Message
+}
+
+func NewStorageError(err error, statusCode int) StorageError {
+	return StorageError{
+		Status:  statusCode,
+		Message: err.Error(),
+	}
+}

--- a/test/fileupload_test.go
+++ b/test/fileupload_test.go
@@ -19,11 +19,11 @@ func TestUpload(t *testing.T) {
 		panic(err)
 	}
 	c := storage_go.NewClient(rawUrl, token, map[string]string{})
-	resp := c.UploadFile("test1", "test.txt", file)
-	fmt.Println(resp)
+	resp, err := c.UploadFile("test", "test.txt", file)
+	fmt.Println(resp, err)
 
-	// resp = c.UploadFile("test1", "hola.txt", []byte("hello world"))
-	// fmt.Println(resp)
+	// resp, err = c.UploadFile("test", "hola.txt", []byte("hello world"))
+	// fmt.Println(resp, err)
 }
 
 func TestUpdate(t *testing.T) {
@@ -32,23 +32,23 @@ func TestUpdate(t *testing.T) {
 		panic(err)
 	}
 	c := storage_go.NewClient(rawUrl, token, map[string]string{})
-	resp := c.UpdateFile("test1", "test.txt", file)
+	resp, err := c.UpdateFile("test", "test.txt", file)
 
-	fmt.Println(resp)
+	fmt.Println(resp, err)
 }
 
 func TestMoveFile(t *testing.T) {
 	c := storage_go.NewClient(rawUrl, token, map[string]string{})
-	resp := c.MoveFile("test1", "test.txt", "random/test.txt")
+	resp, err := c.MoveFile("test", "test.txt", "random/test.txt")
 
-	fmt.Println(resp)
+	fmt.Println(resp, err)
 }
 
 func TestSignedUrl(t *testing.T) {
 	c := storage_go.NewClient(rawUrl, token, map[string]string{})
-	resp := c.CreateSignedUrl("test1", "file_example_MP4_480_1_5MG.mp4", 120)
+	resp, err := c.CreateSignedUrl("test", "file_example_MP4_480_1_5MG.mp4", 120)
 
-	fmt.Println(resp)
+	fmt.Println(resp, err)
 }
 
 func TestPublicUrl(t *testing.T) {
@@ -60,14 +60,14 @@ func TestPublicUrl(t *testing.T) {
 
 func TestDeleteFile(t *testing.T) {
 	c := storage_go.NewClient(rawUrl, token, map[string]string{})
-	resp := c.RemoveFile("shield", []string{"book.pdf"})
+	resp, err := c.RemoveFile("shield", []string{"book.pdf"})
 
-	fmt.Println(resp)
+	fmt.Println(resp, err)
 }
 
 func TestListFile(t *testing.T) {
 	c := storage_go.NewClient(rawUrl, token, map[string]string{})
-	resp := c.ListFiles("test1", "", storage_go.FileSearchOptions{
+	resp, err := c.ListFiles("shield", "", storage_go.FileSearchOptions{
 		Limit:  10,
 		Offset: 0,
 		SortByOptions: storage_go.SortBy{
@@ -76,7 +76,7 @@ func TestListFile(t *testing.T) {
 		},
 	})
 
-	fmt.Println(resp)
+	fmt.Println(resp, err)
 }
 
 func TestCreateUploadSignedUrl(t *testing.T) {
@@ -92,14 +92,14 @@ func TestUploadToSignedUrl(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	resp, err := c.UploadToSignedUrl("signed-url-response", file)
-
-	fmt.Println(resp, err)
+	// resp, err := c.CreateSignedUploadUrl("test", "vu.txt")
+	res, err := c.UploadToSignedUrl("your-response-url", file)
+	fmt.Println(res, err)
 }
 
 func TestDownloadFile(t *testing.T) {
 	c := storage_go.NewClient(rawUrl, token, map[string]string{})
-	resp, err := c.DownloadFile("your-bucket-id", "book.pdf")
+	resp, err := c.DownloadFile("test", "book.pdf")
 	if err != nil {
 		t.Fatalf("DownloadFile failed: %v", err)
 	}

--- a/test/storage_test.go
+++ b/test/storage_test.go
@@ -8,31 +8,42 @@ import (
 )
 
 func TestBucketListAll(t *testing.T) {
-	c := storage_go.NewClient("https://abc.supabase.co/storage/v1", "", map[string]string{})
-	c.ListBuckets()
+	c := storage_go.NewClient(rawUrl, token, map[string]string{})
+	resp, err := c.ListBuckets()
+	fmt.Println(resp, err)
 }
 
 func TestBucketFetchById(t *testing.T) {
-	c := storage_go.NewClient("https://abc.supabase.co/storage/v1", "", map[string]string{})
-	fmt.Println(c.GetBucket("shield"))
+	c := storage_go.NewClient(rawUrl, token, map[string]string{})
+	fmt.Println(c.GetBucket("test"))
 }
 
 func TestBucketCreate(t *testing.T) {
-	c := storage_go.NewClient("https://abc.supabase.co/storage/v1", "", map[string]string{})
-	fmt.Println(c.CreateBucket("test1", storage_go.BucketOptions{
+	c := storage_go.NewClient(rawUrl, token, map[string]string{})
+	fmt.Println(c.CreateBucket("test", storage_go.BucketOptions{
 		Public: true,
 	}))
 }
 
 func TestBucketUpdate(t *testing.T) {
-	c := storage_go.NewClient("https://abc.supabase.co/storage/v1", "", map[string]string{})
-	c.UpdateBucket("test1", storage_go.BucketOptions{
+	c := storage_go.NewClient(rawUrl, token, map[string]string{})
+	_, _ = c.UpdateBucket("test", storage_go.BucketOptions{
 		Public: false,
 	})
 
-	bucket, _ := c.GetBucket("test1")
+	bucket, _ := c.GetBucket("test")
 
 	if bucket.Public {
 		t.Errorf("Should have been private bucket after updating")
 	}
+}
+
+func TestEmptyBucket(t *testing.T) {
+	c := storage_go.NewClient(rawUrl, token, map[string]string{})
+	fmt.Println(c.EmptyBucket("test"))
+}
+
+func TestDeleteBucket(t *testing.T) {
+	c := storage_go.NewClient(rawUrl, token, map[string]string{})
+	fmt.Println(c.DeleteBucket("test"))
 }

--- a/types.go
+++ b/types.go
@@ -15,12 +15,13 @@ type Bucket struct {
 	Name             string   `json:"name"`
 	Owner            string   `json:"owner"`
 	Public           bool     `json:"public"`
-	FileSizeLimit    string   `json:"file_size_limit"`
+	FileSizeLimit    *int64   `json:"file_size_limit"`
 	AllowedMimeTypes []string `json:"allowed_mine_types"`
 	CreatedAt        string   `json:"created_at"`
 	UpdatedAt        string   `json:"updated_at"`
 }
 
+// BucketOptions is used to create or update a Bucket with option
 type BucketOptions struct {
 	Public           bool
 	FileSizeLimit    string
@@ -88,4 +89,17 @@ type SignedUploadUrlResponse struct {
 
 type UploadToSignedUrlResponse struct {
 	Key string `json:"key"`
+}
+
+type FileOptions struct {
+	// The number of seconds the asset is cached in the browser and in the Supabase CDN.
+	// This is set in the `Cache-Control: max-age=<seconds>` header. Defaults to 3600 seconds.
+	CacheControl *string
+	// The `Content-Type` header value. Should be specified if using a `fileBody` that is neither `Blob` nor `File` nor `FormData`, otherwise will default to `text/plain;charset=UTF-8`.
+	ContentType *string
+	// The duplex option is a string parameter that enables or disables duplex streaming, allowing for both reading and writing data in the same stream. It can be passed as an option to the fetch() method.
+	Duplex *string
+	// When upsert is set to true, the file is overwritten if it exists. When set to false, an error is thrown if the object already exists.
+	// Defaults to false.
+	Upsert *bool
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor: Add an error to the function's response to make it clearer and easier to identify errors

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

This is break change: (with old function we will need to add error in response)
```
	file, err := os.Open("dummy.txt")
	if err != nil {
		panic(err)
	}
	c := storage_go.NewClient(rawUrl, token, map[string]string{})
	resp, err := c.UploadFile("test", "test.txt", file)
	fmt.Println(resp, err)
```

## Additional context

Add any other context or screenshots.
