### PR TITLE
set content-type back to default after file upload

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -53,6 +53,10 @@ func (c *Client) UploadOrUpdateFile(
 
 	var response FileUploadResponse
 	_, err = c.Do(req, &response)
+
+	// set content-type back to default after request
+	c.clientTransport.header.Set("content-type", "application/json")
+	
 	if err != nil {
 		return FileUploadResponse{}, err
 	}


### PR DESCRIPTION
## What kind of change does this PR introduce?

* Fix UploadOrUpdateFile permanently changing `content-type` header

## What is the current behavior?

Calling `UploadOrUpdateFile` with the `content-type` changes the content-type for all subsequent requests
```go
func (c *Client) UploadOrUpdateFile(
	bucketId string,
	relativePath string,
	data io.Reader,
	update bool,
	options ...FileOptions,
) (FileUploadResponse, error) {
	path := removeEmptyFolderName(bucketId + "/" + relativePath)
	uploadURL := c.clientTransport.baseUrl.String() + "/object/" + path

	// Check on file options
	if len(options) > 0 {
		if options[0].CacheControl != nil {
			c.clientTransport.header.Set("cache-control", *options[0].CacheControl)
		}
		if options[0].ContentType != nil {
			c.clientTransport.header.Set("content-type", *options[0].ContentType) // <-- here
		}
		if options[0].Upsert != nil {
			c.clientTransport.header.Set("x-upsert", strconv.FormatBool(*options[0].Upsert))
		}
	}
```
This causes #24 

## What is the new behavior?

UploadOrUpdateFile now sets content-type back to "application/json" right after firing the request.

```go
...
if len(options) > 0 {
	if options[0].CacheControl != nil {
		c.clientTransport.header.Set("cache-control", *options[0].CacheControl)
	}
	if options[0].ContentType != nil {
		c.clientTransport.header.Set("content-type", *options[0].ContentType)
	}
	if options[0].Upsert != nil {
		c.clientTransport.header.Set("x-upsert", strconv.FormatBool(*options[0].Upsert))
	}
}
method := http.MethodPost
if update {
	method = http.MethodPut
}
bodyData := bufio.NewReader(data)
req, err := http.NewRequest(method, uploadURL, bodyData)
if err != nil {
	return FileUploadResponse{}, err
}

var response FileUploadResponse
_, err = c.Do(req, &response)

// set content-type back to default after request
c.clientTransport.header.Set("content-type", "application/json")

if err != nil {
	return FileUploadResponse{}, err
}

return response, nil
...
```

## Additional context

Add any other context or screenshots.
