### PR TITLE
Add SetAuthToken to Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,6 @@ func main() {
 	storageClient := storage_go.NewClient("https://<project-reference-id>.supabase.co/storage/v1", nil)
 }
 ```
-
-### Set Api Key for your client
-```go
-  storageClient.SetApiKey("<project-secret-api-key>")
-```
-
 ### Set Auth Token for your client
 ```go
   storageClient.SetAuthToken("<auth-token>")

--- a/README.md
+++ b/README.md
@@ -24,8 +24,18 @@ import (
 )
 
 func main() {
-	storageClient := storage_go.NewClient("https://<project-reference-id>.supabase.co/storage/v1", "<project-secret-api-key>", nil)
+	storageClient := storage_go.NewClient("https://<project-reference-id>.supabase.co/storage/v1", nil)
 }
+```
+
+### Set Api Key for your client
+```go
+  storageClient.SetApiKey("<project-secret-api-key>")
+```
+
+### Set Auth Token for your client
+```go
+  storageClient.SetAuthToken("<auth-token>")
 ```
 
 ### Handling resources
@@ -134,7 +144,7 @@ func main() {
 - Retrieve URLs for assets in public buckets:
 
 ```go
-  result, err := storageClient.GetPublicUrl("test", "book.pdf")
+  result := storageClient.GetPublicUrl("test", "book.pdf")
 ```
 
 - Create an signed URL and upload to signed URL:

--- a/client.go
+++ b/client.go
@@ -13,7 +13,7 @@ var version = "v0.7.0"
 type Client struct {
 	clientError     error
 	session         http.Client
-	clientTransport transport
+	clientTransport *transport
 }
 
 type transport struct {
@@ -31,7 +31,7 @@ func (t transport) RoundTrip(request *http.Request) (*http.Response, error) {
 	return http.DefaultTransport.RoundTrip(request)
 }
 
-func NewClient(rawUrl string, token string, headers map[string]string) *Client {
+func NewClient(rawUrl string, headers map[string]string) *Client {
 	baseURL, err := url.Parse(rawUrl)
 	if err != nil {
 		return &Client{
@@ -46,14 +46,13 @@ func NewClient(rawUrl string, token string, headers map[string]string) *Client {
 
 	c := Client{
 		session:         http.Client{Transport: t},
-		clientTransport: t,
+		clientTransport: &t,
 	}
 
 	// Set required headers
 	c.clientTransport.header.Set("Accept", "application/json")
 	c.clientTransport.header.Set("Content-Type", "application/json")
 	c.clientTransport.header.Set("X-Client-Info", "storage-go/"+version)
-	c.clientTransport.header.Set("Authorization", "Bearer "+token)
 
 	// Optional headers [if exists]
 	for key, value := range headers {
@@ -61,6 +60,18 @@ func NewClient(rawUrl string, token string, headers map[string]string) *Client {
 	}
 
 	return &c
+}
+
+// Sets api key header for subsequent requests
+func (c *Client) SetApiKey(apiKey string) *Client {
+  c.clientTransport.header.Set("apiKey", apiKey)
+  return c
+}
+
+// Sets authorization header for subsequent requests
+func (c *Client) SetAuthToken(authToken string) *Client {
+  c.clientTransport.header.Set("Authorization", "Bearer "+authToken)
+  return c
 }
 
 // NewRequest will create new request with method, url and body

--- a/client.go
+++ b/client.go
@@ -62,12 +62,6 @@ func NewClient(rawUrl string, headers map[string]string) *Client {
 	return &c
 }
 
-// Sets api key header for subsequent requests
-func (c *Client) SetApiKey(apiKey string) *Client {
-  c.clientTransport.header.Set("apiKey", apiKey)
-  return c
-}
-
 // Sets authorization header for subsequent requests
 func (c *Client) SetAuthToken(authToken string) *Client {
   c.clientTransport.header.Set("Authorization", "Bearer "+authToken)

--- a/test/fileupload_test.go
+++ b/test/fileupload_test.go
@@ -81,7 +81,7 @@ func TestListFile(t *testing.T) {
 
 func TestCreateUploadSignedUrl(t *testing.T) {
 	c := storage_go.NewClient(rawUrl, map[string]string{})
-  c.SetApiKey(apiKey)
+  c.SetAuthToken(apiKey)
 	resp, err := c.CreateSignedUploadUrl("your-bucket-id", "book.pdf")
 
 	fmt.Println(resp, err)
@@ -89,7 +89,7 @@ func TestCreateUploadSignedUrl(t *testing.T) {
 
 func TestUploadToSignedUrl(t *testing.T) {
 	c := storage_go.NewClient(rawUrl, map[string]string{})
-  c.SetApiKey(apiKey)
+  c.SetAuthToken(apiKey)
 	file, err := os.Open("dummy.txt")
 	if err != nil {
 		panic(err)

--- a/test/fileupload_test.go
+++ b/test/fileupload_test.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	rawUrl = "https://abc.supabase.co/storage/v1"
-	token  = ""
+  apiKey = ""
 )
 
 func TestUpload(t *testing.T) {
@@ -18,7 +18,7 @@ func TestUpload(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	c := storage_go.NewClient(rawUrl, token, map[string]string{})
+	c := storage_go.NewClient(rawUrl, map[string]string{})
 	resp, err := c.UploadFile("test", "test.txt", file)
 	fmt.Println(resp, err)
 
@@ -31,42 +31,42 @@ func TestUpdate(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	c := storage_go.NewClient(rawUrl, token, map[string]string{})
+	c := storage_go.NewClient(rawUrl, map[string]string{})
 	resp, err := c.UpdateFile("test", "test.txt", file)
 
 	fmt.Println(resp, err)
 }
 
 func TestMoveFile(t *testing.T) {
-	c := storage_go.NewClient(rawUrl, token, map[string]string{})
+	c := storage_go.NewClient(rawUrl, map[string]string{})
 	resp, err := c.MoveFile("test", "test.txt", "random/test.txt")
 
 	fmt.Println(resp, err)
 }
 
 func TestSignedUrl(t *testing.T) {
-	c := storage_go.NewClient(rawUrl, token, map[string]string{})
+	c := storage_go.NewClient(rawUrl, map[string]string{})
 	resp, err := c.CreateSignedUrl("test", "file_example_MP4_480_1_5MG.mp4", 120)
 
 	fmt.Println(resp, err)
 }
 
 func TestPublicUrl(t *testing.T) {
-	c := storage_go.NewClient(rawUrl, token, map[string]string{})
+	c := storage_go.NewClient(rawUrl, map[string]string{})
 	resp := c.GetPublicUrl("shield", "book.pdf")
 
 	fmt.Println(resp)
 }
 
 func TestDeleteFile(t *testing.T) {
-	c := storage_go.NewClient(rawUrl, token, map[string]string{})
+	c := storage_go.NewClient(rawUrl, map[string]string{})
 	resp, err := c.RemoveFile("shield", []string{"book.pdf"})
 
 	fmt.Println(resp, err)
 }
 
 func TestListFile(t *testing.T) {
-	c := storage_go.NewClient(rawUrl, token, map[string]string{})
+	c := storage_go.NewClient(rawUrl, map[string]string{})
 	resp, err := c.ListFiles("shield", "", storage_go.FileSearchOptions{
 		Limit:  10,
 		Offset: 0,
@@ -80,14 +80,16 @@ func TestListFile(t *testing.T) {
 }
 
 func TestCreateUploadSignedUrl(t *testing.T) {
-	c := storage_go.NewClient(rawUrl, token, map[string]string{"apiKey": token})
+	c := storage_go.NewClient(rawUrl, map[string]string{})
+  c.SetApiKey(apiKey)
 	resp, err := c.CreateSignedUploadUrl("your-bucket-id", "book.pdf")
 
 	fmt.Println(resp, err)
 }
 
 func TestUploadToSignedUrl(t *testing.T) {
-	c := storage_go.NewClient(rawUrl, token, map[string]string{"apiKey": token})
+	c := storage_go.NewClient(rawUrl, map[string]string{})
+  c.SetApiKey(apiKey)
 	file, err := os.Open("dummy.txt")
 	if err != nil {
 		panic(err)
@@ -98,7 +100,7 @@ func TestUploadToSignedUrl(t *testing.T) {
 }
 
 func TestDownloadFile(t *testing.T) {
-	c := storage_go.NewClient(rawUrl, token, map[string]string{})
+	c := storage_go.NewClient(rawUrl, map[string]string{})
 	resp, err := c.DownloadFile("test", "book.pdf")
 	if err != nil {
 		t.Fatalf("DownloadFile failed: %v", err)

--- a/test/storage_test.go
+++ b/test/storage_test.go
@@ -8,25 +8,25 @@ import (
 )
 
 func TestBucketListAll(t *testing.T) {
-	c := storage_go.NewClient(rawUrl, token, map[string]string{})
+	c := storage_go.NewClient(rawUrl, map[string]string{})
 	resp, err := c.ListBuckets()
 	fmt.Println(resp, err)
 }
 
 func TestBucketFetchById(t *testing.T) {
-	c := storage_go.NewClient(rawUrl, token, map[string]string{})
+	c := storage_go.NewClient(rawUrl, map[string]string{})
 	fmt.Println(c.GetBucket("test"))
 }
 
 func TestBucketCreate(t *testing.T) {
-	c := storage_go.NewClient(rawUrl, token, map[string]string{})
+	c := storage_go.NewClient(rawUrl, map[string]string{})
 	fmt.Println(c.CreateBucket("test", storage_go.BucketOptions{
 		Public: true,
 	}))
 }
 
 func TestBucketUpdate(t *testing.T) {
-	c := storage_go.NewClient(rawUrl, token, map[string]string{})
+	c := storage_go.NewClient(rawUrl, map[string]string{})
 	_, _ = c.UpdateBucket("test", storage_go.BucketOptions{
 		Public: false,
 	})
@@ -39,11 +39,11 @@ func TestBucketUpdate(t *testing.T) {
 }
 
 func TestEmptyBucket(t *testing.T) {
-	c := storage_go.NewClient(rawUrl, token, map[string]string{})
+	c := storage_go.NewClient(rawUrl, map[string]string{})
 	fmt.Println(c.EmptyBucket("test"))
 }
 
 func TestDeleteBucket(t *testing.T) {
-	c := storage_go.NewClient(rawUrl, token, map[string]string{})
+	c := storage_go.NewClient(rawUrl, map[string]string{})
 	fmt.Println(c.DeleteBucket("test"))
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

The PR resolves (#29)[https://github.com/supabase-community/storage-go/issues/29]

## What is the current behavior?

Auth token can only be set from the Client creation method

## What is the new behavior?

Now it is possible to set the auth token whenever needed 

## Additional context
