### PR TITLE
feat: add CreateSignedUrls method

### DIFF
--- a/test/fileupload_test.go
+++ b/test/fileupload_test.go
@@ -51,6 +51,16 @@ func TestSignedUrl(t *testing.T) {
 	fmt.Println(resp, err)
 }
 
+func TestSignedUrls(t *testing.T) {
+	c := storage_go.NewClient(rawUrl, token, map[string]string{})
+	resp, err := c.CreateSignedUrls("test", []string{"file_example_MP4_480_1_5MG.mp4", "test.txt"}, 120)
+	if err != nil {
+		t.Fatalf("CreateSignedUrls failed: %v", err)
+	}
+
+	fmt.Println(resp, err)
+}
+
 func TestPublicUrl(t *testing.T) {
 	c := storage_go.NewClient(rawUrl, token, map[string]string{})
 	resp := c.GetPublicUrl("shield", "book.pdf")


### PR DESCRIPTION
## What kind of change does this PR introduce?

New feature

## What is the current behavior?

Currently creating a batch of signed urls in one request is not supported. #31 

## What is the new behavior?

`CreateSignedUrls` method mirrors the behavior of the `storage-js` package, allowing for creating multiple signed urls at once.

## Additional context

Added a test to verify proper behavior.
