### PR TITLE
Fix to handle concurrent requests correctly

### DIFF
--- a/client.go
+++ b/client.go
@@ -22,11 +22,6 @@ type transport struct {
 }
 
 func (t transport) RoundTrip(request *http.Request) (*http.Response, error) {
-	for headerName, values := range t.header {
-		for _, val := range values {
-			request.Header.Add(headerName, val)
-		}
-	}
 	request.URL = t.baseUrl.ResolveReference(request.URL)
 	return http.DefaultTransport.RoundTrip(request)
 }
@@ -80,6 +75,15 @@ func (c *Client) NewRequest(method, url string, body ...interface{}) (*http.Requ
 	if err != nil {
 		return nil, err
 	}
+
+	// Copy transport headers to request headers.
+	// This prevents concurrent modification of headers if you have multiple requests.
+	for k, headers := range c.clientTransport.header {
+		for _, v := range headers {
+			req.Header.Add(k, v)
+		}
+	}
+
 	return req, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/supabase-community/storage-go
 
-go 1.17
+go 1.18

--- a/storage.go
+++ b/storage.go
@@ -29,18 +29,6 @@ func (c *Client) UploadOrUpdateFile(
 	path := removeEmptyFolderName(bucketId + "/" + relativePath)
 	uploadURL := c.clientTransport.baseUrl.String() + "/object/" + path
 
-	// Check on file options
-	if len(options) > 0 {
-		if options[0].CacheControl != nil {
-			c.clientTransport.header.Set("cache-control", *options[0].CacheControl)
-		}
-		if options[0].ContentType != nil {
-			c.clientTransport.header.Set("content-type", *options[0].ContentType)
-		}
-		if options[0].Upsert != nil {
-			c.clientTransport.header.Set("x-upsert", strconv.FormatBool(*options[0].Upsert))
-		}
-	}
 	method := http.MethodPost
 	if update {
 		method = http.MethodPut
@@ -51,12 +39,22 @@ func (c *Client) UploadOrUpdateFile(
 		return FileUploadResponse{}, err
 	}
 
+	// Check on file options
+	if len(options) > 0 {
+		if options[0].CacheControl != nil {
+			req.Header.Set("cache-control", *options[0].CacheControl)
+		}
+		if options[0].ContentType != nil {
+			req.Header.Set("content-type", *options[0].ContentType)
+		}
+		if options[0].Upsert != nil {
+			req.Header.Set("x-upsert", strconv.FormatBool(*options[0].Upsert))
+		}
+	}
+
 	var response FileUploadResponse
 	_, err = c.Do(req, &response)
 
-	// set content-type back to default after request
-	c.clientTransport.header.Set("content-type", "application/json")
-	
 	if err != nil {
 		return FileUploadResponse{}, err
 	}

--- a/test/fileupload_test.go
+++ b/test/fileupload_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 
 	storage_go "github.com/supabase-community/storage-go"
@@ -108,4 +109,32 @@ func TestDownloadFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("WriteFile failed: %v", err)
 	}
+}
+
+// TestConcurrentFileUpload tests concurrent file uploads to a bucket.
+// To correctly ensure this catches bugs run with the race detector.
+func TestConcurrentFileUpload(t *testing.T) {
+	c := storage_go.NewClient(rawUrl, token, map[string]string{})
+	file, _ := os.Open("dummy.txt")
+	defer file.Close()
+
+	const concurrent = 8
+	wg := sync.WaitGroup{}
+	wg.Add(concurrent)
+
+	for i := 0; i < concurrent; i++ {
+		go func(index int) {
+			c.UploadFile("test", fmt.Sprintf("test%d.txt", index), file, storage_go.FileOptions{
+				CacheControl: ptr("public, max-age=3600"),
+				ContentType:  ptr("text/plain"),
+				Upsert:       ptr(true),
+			})
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
+}
+
+func ptr[T any](v T) *T {
+	return &v
 }

--- a/test/storage_test.go
+++ b/test/storage_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/supabase-community/storage-go"
+	storage_go "github.com/supabase-community/storage-go"
 )
 
 func TestBucketListAll(t *testing.T) {


### PR DESCRIPTION
## What kind of change does this PR introduce?
Copies headers from the transport instead of using them directly. This still probably isn't the "best" solution (we don't need a custom transport for this) but at least its threadsafe now.


## What is the current behavior?

I was hitting this issue in my own code when trying to upload multiple files concurrently.

Someone reported it here:
https://github.com/supabase-community/storage-go/issues/27

## What is the new behavior?

It no longer crashes.

## Additional context

N/A