### PR TITLE
Support new Supabase API key format

### DIFF
--- a/client.go
+++ b/client.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 var version = "v0.8.1"
@@ -53,7 +54,17 @@ func NewClient(rawUrl string, token string, headers map[string]string) *Client {
 	c.clientTransport.header.Set("Accept", "application/json")
 	c.clientTransport.header.Set("Content-Type", "application/json")
 	c.clientTransport.header.Set("X-Client-Info", "storage-go/"+version)
-	c.clientTransport.header.Set("Authorization", "Bearer "+token)
+	c.clientTransport.header.Set("apikey", token)
+
+	// New-style Supabase API keys (sb_publishable_... / sb_secret_...) are not JWTs
+	// and cannot be used with a "Bearer " prefix in the Authorization header.
+	// For these keys, set Authorization to the exact same value as apikey (backward-compat mode).
+	// Legacy JWT-based keys (anon / service_role) keep the standard Bearer scheme.
+	if strings.HasPrefix(token, "sb_") {
+		c.clientTransport.header.Set("Authorization", token)
+	} else {
+		c.clientTransport.header.Set("Authorization", "Bearer "+token)
+	}
 
 	// Optional headers [if exists]
 	for key, value := range headers {

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,74 @@
+package storage_go
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestNewClientHeaders verifies that NewClient sets the correct HTTP headers
+// for both legacy JWT tokens and new-style Supabase API keys.
+func TestNewClientHeaders(t *testing.T) {
+	tests := []struct {
+		name              string
+		token             string
+		wantApikey        string
+		wantAuthorization string
+	}{
+		{
+			name:              "legacy JWT token gets Bearer prefix",
+			token:             "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test",
+			wantApikey:        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test",
+			wantAuthorization: "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test",
+		},
+		{
+			name:              "new publishable key does not get Bearer prefix",
+			token:             "sb_publishable_abc123",
+			wantApikey:        "sb_publishable_abc123",
+			wantAuthorization: "sb_publishable_abc123",
+		},
+		{
+			name:              "new secret key does not get Bearer prefix",
+			token:             "sb_secret_xyz789",
+			wantApikey:        "sb_secret_xyz789",
+			wantAuthorization: "sb_secret_xyz789",
+		},
+		{
+			name:              "empty token falls back to Bearer scheme",
+			token:             "",
+			wantApikey:        "",
+			wantAuthorization: "Bearer",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var capturedReq *http.Request
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedReq = r
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("[]"))
+			}))
+			defer srv.Close()
+
+			c := NewClient(srv.URL, tc.token, map[string]string{})
+			req, err := c.NewRequest(http.MethodGet, "/bucket")
+			if err != nil {
+				t.Fatalf("NewRequest failed: %v", err)
+			}
+			if _, err = c.Do(req, nil); err != nil {
+				t.Fatalf("Do failed: %v", err)
+			}
+
+			gotApikey := capturedReq.Header.Get("Apikey")
+			gotAuthorization := capturedReq.Header.Get("Authorization")
+
+			if gotApikey != tc.wantApikey {
+				t.Errorf("apikey header: got %q, want %q", gotApikey, tc.wantApikey)
+			}
+			if gotAuthorization != tc.wantAuthorization {
+				t.Errorf("Authorization header: got %q, want %q", gotAuthorization, tc.wantAuthorization)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request updates the way HTTP headers are set for authentication in the `NewClient` function to correctly support both legacy JWT tokens and new-style Supabase API keys. It also adds comprehensive tests to verify the new behavior.

**Authentication header handling:**

* Updated `NewClient` in `client.go` to set the `Authorization` header differently based on the token type: new-style Supabase API keys (those starting with `sb_`) are now sent as-is (without a `Bearer` prefix), while legacy JWT tokens continue to use the `Bearer` scheme. The `apikey` header is always set to the raw token. This ensures compatibility with Supabase's evolving authentication requirements.

**Testing:**

* Added a new test `TestNewClientHeaders` in `client_test.go` to verify that both `apikey` and `Authorization` headers are set correctly for different token formats, covering legacy JWTs, new publishable/secret keys, and the empty token case.

**Dependency update:**

* Imported the `strings` package in `client.go` to facilitate token prefix checking.